### PR TITLE
Remove unnecessary provider block

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.region
-}
-
 module "aws_lambda_function" {
   source = "terraform-aws-modules/lambda/aws"
 


### PR DESCRIPTION
No need for the additional `provider` block due to it being redundant with the source terraform-aws-modules/lambda/aws module